### PR TITLE
Add a variable to allow key configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,16 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+locals {
+    platform_prefix = (var.datacenter == "" ? data.aws_iam_account_alias.current.account_alias : var.datacenter)
+}
+
 data "aws_iam_account_alias" "current" {}
 
 data "aws_s3_object" "platform_config" {
   provider = aws.platform_config_bucket
   bucket = var.bucket
-  key = "${data.aws_iam_account_alias.current.account_alias}/${var.platform_config_region}.json"
+  key = "${local.platform_prefix}/${var.platform_config_region}.json"
 }
 
 output "config" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "platform_config_region" {
     default     = "eu-west-1"
     description = "Aws region of desired platform target"
 }
+
+variable "datacenter" {
+    type = string
+    default = ""
+    description = "Use this variable to specify a platform_config folder that differs from the account alias"
+}


### PR DESCRIPTION
Add a variable (I've chosen `datacenter` for the name, but I know that's an overloaded term. If you've a better suggestion please let me know) that allows the bucket directory to differ from the AWS account alias.

This allows us to have 2 different platform-configs for the same AWS account / region such as oh1-prod vs oh1-beta

The datacenter variable is optional and the default behavior matches the current behavior so this should be a non-breaking change