### PR TITLE
Change BSG datacenter to a direct S3 path with platform_config_key.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 locals {
   region = var.platform_config_region != "" ? var.platform_config_region : data.aws_region.current.name
-  platform_prefix = (var.datacenter == "" ? data.aws_iam_account_alias.current.account_alias : var.datacenter)
+  platform_config_key = coalesce(var.platform_config_key, "${data.aws_iam_account_alias.current.account_alias}/${local.region}.json")
 }
-
 provider "aws" {
   alias = "platform_config_bucket"
   region = "eu-west-1"
@@ -15,7 +14,7 @@ data "aws_iam_account_alias" "current" {}
 data "aws_s3_object" "platform_config" {
   provider = aws.platform_config_bucket
   bucket = var.bucket
-  key = "${local.platform_prefix}/${local.region}.json"
+  key = local.platform_config_key
 }
 
 output "config" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  region = var.platform_config_region != "" ? var.platform_config_region : data.aws_region.current.name
+  region = coalesce(var.platform_config_region, data.aws_region.current.name)
   platform_config_key = coalesce(var.platform_config_key, "${data.aws_iam_account_alias.current.account_alias}/${local.region}.json")
 }
 provider "aws" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,8 @@ variable "platform_config_region" {
     description = "Aws region of desired platform target"
 }
 
-variable "datacenter" {
+variable "platform_config_key" {
     type = string
     default = ""
-    description = "Use this variable to specify a platform_config folder that differs from the account alias"
+    description = "Set the S3 bucket key's direct path for use within the platform_config."
 }


### PR DESCRIPTION
BSG wants to move away from using `datacenter` and instead manage the platform JSON config by directly referencing the path in the `platform_config` module. This offers more control over the configuration file selection. Usually pattern `capplatformbsg/${ecs_cluster}.json` will be used for exampe:
```
module "platform_config" {
    source = "mergermarket/platform-config/acuris" 
    platform_config_key = "capplatformbsg/${ecs_cluster}.json"
    bucket = "acuris-platform-config"
}
```

I also used there terraform `coalesce()` method to select the value to be used :
https://developer.hashicorp.com/terraform/language/functions/coalesce
> coalesce takes any number of arguments and returns the first one that isn't null or an empty string.

